### PR TITLE
Fix GRPC Logo sizing

### DIFF
--- a/assets/icons/IconGrpcLogo.tsx
+++ b/assets/icons/IconGrpcLogo.tsx
@@ -9,7 +9,7 @@ interface IconProps extends React.SVGAttributes<SVGElement> {
 
 export const IconGrpcLogo: React.FunctionComponent<IconProps> = ({
   color = "currentColor",
-  size = 75,
+  size = "1em",
   ...other
 }) => {
   return (

--- a/src/sections/SkillsSection.tsx
+++ b/src/sections/SkillsSection.tsx
@@ -64,7 +64,7 @@ export const SkillsSection: React.FC<SkillsSectionProps> = (props) => {
                   <td colSpan={1} className={styles.skillTd} key={anchorId}>
                     <a id={anchorId}>
                       <IconContext.Provider value={techIconConfig}>
-                        <TechIcon />
+                        <TechIcon className={techIconConfig.className} />
                       </IconContext.Provider>
                     </a>
                     <Tooltip

--- a/src/styles/scss/sections/skills_section.scss
+++ b/src/styles/scss/sections/skills_section.scss
@@ -45,6 +45,5 @@
 }
 
 .techIcon {
-    height: map-get($font-sizes, "subtitle");
-    width: map-get($font-sizes, "subtitle");
+    font-size: map-get($font-sizes, "subtitle");
 }


### PR DESCRIPTION
Could not implement `IconContext.Consumer` inside custom logo, hence just passed the class name directly to the icons. 
Those native icons consuming from the Provider would consume as usual, custom icons would directly get the class name from props.