### PR TITLE
Disable Body scroll on open nav bar

### DIFF
--- a/src/action_creators/index.ts
+++ b/src/action_creators/index.ts
@@ -26,6 +26,8 @@ export const setScreenSize: ActionCreator<ScreenSizeAction> = (
 export const setNavActive: ActionCreator<NavActiveAction> = (
   value: boolean
 ) => {
+  const body = document.getElementsByTagName("body")[0];
+  body.setAttribute("data-nav-open", String(value));
   return {
     type: "SET_NAV_ACTIVE",
     value,

--- a/src/components/ScreenSizeListener.tsx
+++ b/src/components/ScreenSizeListener.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from "react";
-import { setScreenSize } from "rb3198/action_creators";
+import { setNavActive, setScreenSize } from "rb3198/action_creators";
 import { ConnectedProps, connect } from "react-redux";
 import { Dispatch, bindActionCreators } from "redux";
 import { Screens } from "rb3198/types/enum/Screens";
@@ -7,7 +7,7 @@ import { Screens } from "rb3198/types/enum/Screens";
 type ReduxProps = ConnectedProps<typeof connector>;
 
 const ScreenSizeListenerComponent: React.FC<ReduxProps> = (props) => {
-  const { setScreenSize } = props;
+  const { setScreenSize, setNavActive } = props;
 
   const screenSizeListener = useCallback(() => {
     switch (true) {
@@ -32,7 +32,10 @@ const ScreenSizeListenerComponent: React.FC<ReduxProps> = (props) => {
       default:
         break;
     }
-  }, [setScreenSize]);
+    if (window.innerWidth > Screens.Small) {
+      setNavActive(false);
+    }
+  }, [setScreenSize, setNavActive]);
 
   useEffect(() => {
     screenSizeListener();
@@ -49,6 +52,7 @@ const ScreenSizeListenerComponent: React.FC<ReduxProps> = (props) => {
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
     setScreenSize: bindActionCreators(setScreenSize, dispatch),
+    setNavActive: bindActionCreators(setNavActive, dispatch),
   };
 };
 

--- a/src/styles/scss/work_card.scss
+++ b/src/styles/scss/work_card.scss
@@ -95,8 +95,8 @@
     @include media("mobile") {
         border-width: 1px;
         width: map-get($pc_spacing, 8);
-        margin-top: map-get($abs_spacing, 2);
-        margin-bottom: map-get($abs_spacing, 2);
+        margin-top: map-get($abs_spacing, 4);
+        margin-bottom: map-get($abs_spacing, 4);
     }
 }
 

--- a/theme/index.scss
+++ b/theme/index.scss
@@ -86,7 +86,7 @@ body[data-theme="2"][data-modal-open="false"]::-webkit-scrollbar {
     background-color: list.nth($primary_background, 2);
 }
 
-body[data-modal-open="true"] {
+body[data-modal-open="true"], body[data-nav-open="true"] {
     overflow-y: hidden;
 }
 


### PR DESCRIPTION
- Styled based on data-nav-open attribute
- Set this attribute to body tag whenever nav opens / closes
- Set it to false if screen gets resized to bigger than the minimum for hamburger menu